### PR TITLE
Fix filename casing in six include statements

### DIFF
--- a/src/parser/include/AST.h
+++ b/src/parser/include/AST.h
@@ -1,7 +1,7 @@
 #ifndef PULSE_VHDL_ASTBUILDER_H
 #define PULSE_VHDL_ASTBUILDER_H
 
-#include "Tokenizer.h"
+#include "tokenizer.h"
 #include "signalInterface.h"
 #include <vector>
 #include <string>

--- a/src/parser/include/blueprintGenerator.h
+++ b/src/parser/include/blueprintGenerator.h
@@ -1,7 +1,7 @@
 #ifndef PULSE_VHDL_BLUEPRINT_GENERATOR_H
 #define PULSE_VHDL_BLUEPRINT_GENERATOR_H
 
-#include "Linker.h"
+#include "linker.h"
 #include "blueprint.h"
 #include <unordered_map>
 #include <memory>

--- a/src/parser/linker_core.cc
+++ b/src/parser/linker_core.cc
@@ -1,4 +1,4 @@
-#include "Linker.h"
+#include "linker.h"
 
 namespace Pulse::Parser
 {

--- a/src/parser/tests/AST.test.cc
+++ b/src/parser/tests/AST.test.cc
@@ -2,7 +2,7 @@
 #include <sstream>
 #include <memory>
 #include "AST.h"
-#include "Tokenizer.h"
+#include "tokenizer.h"
 
 using namespace Pulse::Parser;
 

--- a/src/parser/tests/linker.test.cc
+++ b/src/parser/tests/linker.test.cc
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "Linker.h"
+#include "linker.h"
 #include <memory>
 
 using namespace Pulse::Parser;

--- a/src/parser/tests/semanticAnalyzer.test.cc
+++ b/src/parser/tests/semanticAnalyzer.test.cc
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include <stdexcept>
-#include "SemanticAnalyzer.h"
+#include "semanticAnalyzer.h"
 
 namespace Pulse::Parser::Tests
 {


### PR DESCRIPTION
## Description
Fix compiler errors due to filename case mismatches in six include statements.

## Change Type
Minor syntactical fix.

## Motivation and Context
It is necessary for the code to compile when using a filesystem that is case-sensitive. It solves the  problem that the code would not compile when using a filesystem that is case-sensitive. It improves the project by allowing the code to compile when using a filesystem that is case-sensitive.

## Checklist
- [✅] I have read the contributing guidelines.
- [✅] I have added tests for my changes (if applicable).
- [✅] I have updated the documentation (if applicable).
- [✅] I have run the tests and the test project and verified everything is working as expected.

## Additional Notes
It feels like a linter or something should catch stuff like this, but I'm not a dev so idk ¯\\\_(ツ)_/¯